### PR TITLE
Refactor: Bypass for SSL error AMQP on Hyperf

### DIFF
--- a/app/Amqp/SSL/IOFactoryCustom.php
+++ b/app/Amqp/SSL/IOFactoryCustom.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Amqp\SSL;
+
+use Hyperf\Amqp\IO\IOFactoryInterface;
+use Hyperf\Amqp\Params;
+use PhpAmqpLib\Wire\IO\AbstractIO;
+
+class IOFactoryCustom implements IOFactoryInterface
+{
+    public function create(array $config, Params $params): AbstractIO
+    {
+        $host = $config['host'] ?? 'localhost';
+        $port = $config['port'] ?? 5672;
+        $openSsl = $config['ssl']['open_ssl'] ?? false;
+        $sslOptions = $config['ssl'] ?? [];
+
+        return new SwooleIOCustom(
+            host: $host,
+            port: $port,
+            connectionTimeout: $params->getConnectionTimeout(),
+            readWriteTimeout: $params->getReadWriteTimeout(),
+            sslOptions: $sslOptions,
+        );
+    }
+}

--- a/app/Amqp/SSL/SwooleIOCustom.php
+++ b/app/Amqp/SSL/SwooleIOCustom.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Amqp\SSL;
+
+use Hyperf\Amqp\IO\SwooleIO as IOSwooleIO;
+use PhpAmqpLib\Exception\AMQPRuntimeException;
+use Swoole\Coroutine\Socket;
+
+class SwooleIOCustom extends IOSwooleIO
+{
+    public function __construct(
+        string $host,
+        int $port,
+        protected int $connectionTimeout,
+        protected int $readWriteTimeout = 3,
+        protected array $sslOptions = [],
+    ) {
+        parent::__construct($host, $port, $connectionTimeout, $readWriteTimeout);
+    }
+
+    protected function makeClient(): Socket
+    {
+        $sock = new Socket(AF_INET, SOCK_STREAM, 0);
+
+        if ($this->sslOptions['open_ssl'] === true) {
+            $sock->setProtocol($this->sslOptions);
+        }
+
+        if (! $sock->connect($this->host, $this->port, $this->connectionTimeout)) {
+            throw new AMQPRuntimeException(
+                sprintf('Error Connecting to server: %s ', $sock->errMsg),
+                $sock->errCode
+            );
+        }
+        return $sock;
+    }
+}

--- a/config/autoload/amqp.php
+++ b/config/autoload/amqp.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Amqp\SSL\IOFactoryCustom;
 use Hyperf\Amqp\IO\IOFactory;
 
 use function Hyperf\Support\env;
@@ -14,14 +15,18 @@ return [
         'user' => env('AMQP_USER', 'guest'),
         'password' => env('AMQP_PASSWORD', 'guest'),
         'vhost' => env('AMQP_VHOST', '/'),
-        'open_ssl' => true,
         'concurrent' => [
             'limit' => 2,
         ],
         'pool' => [
             'connections' => 2,
         ],
-        'io' => IOFactory::class,
+        'io' => IOFactoryCustom::class,
+        'ssl' => [
+            'open_ssl' => true,
+            'ssl_cert_file' => '/opt/www/.docker/rabbitmq/certs/server-cert.pem',
+            'ssl_key_file' => '/opt/www/.docker/rabbitmq/certs/server-key.pem',
+        ],
         'params' => [
             'insist' => false,
             'login_method' => 'AMQPLAIN',
@@ -30,15 +35,15 @@ return [
             'connection_timeout' => 3,
             // Try to maintain twice value heartbeat as much as possible
             'read_write_timeout' => 6,
-            'context' => stream_context_create([
-                'ssl' => [
-                    'cafile' => '/opt/www/.docker/rabbitmq/certs/ca.pem',
-                    'local_cert' => '/opt/www/.docker/rabbitmq/certs/server-cert.pem',
-                    'local_pk' => '/opt/www/.docker/rabbitmq/certs/server-key.pem',
-                    'verify_peer' => true,
-                    'verify_peer_name' => false,
-                ],
-            ]),
+            // 'context' => stream_context_create([
+            //     'ssl' => [
+            //         'cafile' => '/opt/www/.docker/rabbitmq/certs/ca.pem',
+            //         'local_cert' => '/opt/www/.docker/rabbitmq/certs/server-cert.pem',
+            //         'local_pk' => '/opt/www/.docker/rabbitmq/certs/server-key.pem',
+            //         'verify_peer' => true,
+            //         'verify_peer_name' => false,
+            //     ],
+            // ]),
             'keepalive' => true,
             // Try to ensure that the consumption time of each message is less than the heartbeat time as much as possible
             'heartbeat' => 3,


### PR DESCRIPTION
Mitigate ssl error creating an custom `SwooleIO` class for make the client and passing ssl file certs to the socket server of Swoole.

![Screenshot 2025-01-23 192750](https://github.com/user-attachments/assets/7188155d-e198-4550-bfd5-0b1c8a90f84d)

![Screenshot 2025-01-23 192802](https://github.com/user-attachments/assets/c3516a51-53da-470b-b8e6-f37ea1a42e1e)

I would say that this problem was being fixed, but the Hyperf creator closed the pull request related to the fix:
- https://github.com/hyperf/hyperf/pull/4421

and this:
- https://github.com/hyperf/hyperf/pull/4420/files
![Screenshot 2025-01-23 193646](https://github.com/user-attachments/assets/18558e73-2b2b-4011-8df3-bd215919696a)
